### PR TITLE
Fix error while parsing of symbols

### DIFF
--- a/quarkToJson.scd
+++ b/quarkToJson.scd
@@ -7,7 +7,7 @@ q[\toJson] = {|v|
 	{v.class == Association} { q[\toJson].value(v.key) }
 	{v===true} { "true" }
 	{v===false} { "false" }
-	{v.isString} { "\"%\"".format(v.replace("\"", "\\\"")).replace("\n", "\\n").replace("\t", " ") }
+	{v.isString} { "\"%\"".format(v.asString.replace("\"", "\\\"")).replace("\n", "\\n").replace("\t", " ") }
 	{v.class == Symbol } { "\"%\"".format(v.replace("\"", "\\\"")).replace("\n", "\\n") }
 	{v.isNil} {val = "null"}
 	{v.isFloat} { "%".format(v)}

--- a/quarkToJson.scd
+++ b/quarkToJson.scd
@@ -7,8 +7,8 @@ q[\toJson] = {|v|
 	{v.class == Association} { q[\toJson].value(v.key) }
 	{v===true} { "true" }
 	{v===false} { "false" }
-	{v.isString} { "\"%\"".format(v.asString.replace("\"", "\\\"")).replace("\n", "\\n").replace("\t", " ") }
-	{v.class == Symbol } { "\"%\"".format(v.replace("\"", "\\\"")).replace("\n", "\\n") }
+	{v.isString} { "\"%\"".format(v.replace("\"", "\\\"")).replace("\n", "\\n").replace("\t", " ") }
+	{v.class == Symbol } { "\"%\"".format(v.asString.replace("\"", "\\\"")).replace("\n", "\\n") }
 	{v.isNil} {val = "null"}
 	{v.isFloat} { "%".format(v)}
 	{v.isInteger} { "%".format(v)}


### PR DESCRIPTION
Thanks for this! I also have a hacky implementation, but this one is more readable. 

the Symbol class does not have a method 'replace' like a string does. A quick and dirty call to `asString` fixes that, but has only been tested on symbols that are one word of alpahbetical characters.